### PR TITLE
Fix silent failure in Python runner

### DIFF
--- a/cmd/runners/install.go
+++ b/cmd/runners/install.go
@@ -80,7 +80,11 @@ template_path = %q
 [runner.open]
 interpreter = "python3"
 args = ["-B", "{wrapper_file}"]
-env = ["PYTHONPATH={lang_dir}/../../../lib:{lang_dir}"]
+# PYTHONPATH entries: the exercise dir ({lang_dir}/..) so the wrapper's
+# "from py import Exercise" resolves, plus a shared library dir. The lib path
+# below assumes a lib/ at the project root (exercises/<year>/<day>/py -> four
+# levels up); adjust if your shared package lives elsewhere.
+env = ["PYTHONPATH={lang_dir}/..:{lang_dir}/../../../../lib"]
 
 [[runner]]
 key = "go"

--- a/pkg/runners/comm.go
+++ b/pkg/runners/comm.go
@@ -67,7 +67,12 @@ func setupBuffers(cmd *exec.Cmd) (io.WriteCloser, error) {
 	return cmd.StdinPipe()
 }
 
-func checkWait(cmd *exec.Cmd) ([]byte, error) {
+// checkWait returns the next stdout entry from the command, blocking until one
+// is available. The exited channel must be closed by the sole owner of
+// cmd.Wait() once the process terminates; checkWait uses it to detect a
+// subprocess that died without producing output (e.g. a startup crash) and
+// returns its exit code and stderr rather than spinning forever.
+func checkWait(cmd *exec.Cmd, exited <-chan struct{}) ([]byte, error) {
 	const checkWaitDelay time.Duration = 10 * time.Millisecond
 
 	c := cmd.Stdout.(*customWriter) //nolint:errcheck // we will handle errors in the loop
@@ -78,21 +83,28 @@ func checkWait(cmd *exec.Cmd) ([]byte, error) {
 			return e, nil
 		}
 
-		if cmd.ProcessState != nil {
+		select {
+		case <-exited:
+			// Re-check for a final entry that may have landed alongside exit, so
+			// a process that wrote its result and then exited still succeeds.
+			if finalEntry, getErr := c.GetEntry(); getErr == nil {
+				return finalEntry, nil
+			}
+
 			stderrBuf, _ := cmd.Stderr.(*bytes.Buffer)
 			return nil, fmt.Errorf(
 				"run failed with exit code %d: %s",
 				cmd.ProcessState.ExitCode(),
 				stderrBuf.String())
+		default:
+			time.Sleep(checkWaitDelay)
 		}
-
-		time.Sleep(checkWaitDelay)
 	}
 }
 
-func readJSONFromCommand(res any, cmd *exec.Cmd) error {
+func readJSONFromCommand(res any, cmd *exec.Cmd, exited <-chan struct{}) error {
 	for {
-		inp, err := checkWait(cmd)
+		inp, err := checkWait(cmd, exited)
 		if err != nil {
 			return err
 		}

--- a/pkg/runners/comm_test.go
+++ b/pkg/runners/comm_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"os/exec"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -189,6 +190,17 @@ func TestSetupBuffers(t *testing.T) {
 	}
 }
 
+// reaped runs cmd to completion (populating ProcessState) and returns a closed
+// channel, modelling the post-Wait state the reaper goroutine signals via the
+// runner's exited channel.
+func reaped(cmd *exec.Cmd) <-chan struct{} {
+	_ = cmd.Run()
+	ch := make(chan struct{})
+	close(ch)
+
+	return ch
+}
+
 func Test_checkWait(t *testing.T) {
 	t.Run("returns entry when available", func(t *testing.T) {
 		cw := &customWriter{
@@ -198,7 +210,8 @@ func Test_checkWait(t *testing.T) {
 		cmd.Stdout = cw
 		cmd.Stderr = new(bytes.Buffer)
 
-		got, err := checkWait(cmd)
+		// Process still running: an open channel never fires the exit path.
+		got, err := checkWait(cmd, make(chan struct{}))
 
 		require.NoError(t, err)
 		assert.JSONEq(t, `{"task_id":"1","ok":true}`, string(got))
@@ -210,9 +223,7 @@ func Test_checkWait(t *testing.T) {
 		cmd.Stdout = cw
 		cmd.Stderr = new(bytes.Buffer)
 
-		_ = cmd.Run() // sets ProcessState
-
-		got, err := checkWait(cmd)
+		got, err := checkWait(cmd, reaped(cmd))
 
 		require.Error(t, err)
 		assert.Nil(t, got)
@@ -226,16 +237,49 @@ func Test_checkWait(t *testing.T) {
 		cmd.Stdout = cw
 		cmd.Stderr = new(bytes.Buffer)
 
-		_ = cmd.Run()
-
-		got, err := checkWait(cmd)
+		got, err := checkWait(cmd, reaped(cmd))
 
 		require.Error(t, err)
 		assert.Nil(t, got)
 		assert.Contains(t, err.Error(), "exit code 1")
 	})
 
-	t.Run("prefers entries over process state", func(t *testing.T) {
+	t.Run("returns error when process dies without producing output", func(t *testing.T) {
+		// Real-world path: the subprocess crashes on startup (writes to stderr,
+		// nothing to stdout). checkWait must detect exit via the closed channel
+		// and return its error rather than spinning forever. The timeout guard
+		// fails loudly if it hangs.
+		cmd := exec.Command("sh", "-c", "echo 'startup crash' >&2; exit 3")
+		cw := &customWriter{}
+		cmd.Stdout = cw
+		cmd.Stderr = new(bytes.Buffer)
+
+		exited := reaped(cmd)
+		done := make(chan struct{})
+
+		var (
+			got []byte
+			err error
+		)
+
+		go func() {
+			got, err = checkWait(cmd, exited)
+			close(done)
+		}()
+
+		select {
+		case <-done:
+		case <-time.After(5 * time.Second):
+			t.Fatal("checkWait hung on a dead subprocess")
+		}
+
+		require.Error(t, err)
+		assert.Nil(t, got)
+		assert.Contains(t, err.Error(), "exit code 3")
+		assert.Contains(t, err.Error(), "startup crash")
+	})
+
+	t.Run("prefers entries over process exit", func(t *testing.T) {
 		// Even if the process has exited, available entries are returned first.
 		cmd := exec.Command("true")
 		cw := &customWriter{
@@ -244,9 +288,7 @@ func Test_checkWait(t *testing.T) {
 		cmd.Stdout = cw
 		cmd.Stderr = new(bytes.Buffer)
 
-		_ = cmd.Run() // ProcessState is set, but entries exist
-
-		got, err := checkWait(cmd)
+		got, err := checkWait(cmd, reaped(cmd))
 
 		require.NoError(t, err)
 		assert.Equal(t, []byte("result data"), got)
@@ -264,10 +306,10 @@ func Test_readJSONFromCommand(t *testing.T) {
 		cmd.Stdout = cw
 		cmd.Stderr = new(bytes.Buffer)
 
-		_ = cmd.Run()
+		exited := reaped(cmd)
 
 		var result protocol.Result
-		err := readJSONFromCommand(&result, cmd)
+		err := readJSONFromCommand(&result, cmd, exited)
 
 		require.NoError(t, err)
 		assert.Equal(t, "abc", result.TaskID)
@@ -288,10 +330,10 @@ func Test_readJSONFromCommand(t *testing.T) {
 		cmd.Stdout = cw
 		cmd.Stderr = new(bytes.Buffer)
 
-		_ = cmd.Run()
+		exited := reaped(cmd)
 
 		var result protocol.Result
-		err := readJSONFromCommand(&result, cmd)
+		err := readJSONFromCommand(&result, cmd, exited)
 
 		require.NoError(t, err)
 		assert.Equal(t, "answer", result.Output)
@@ -307,10 +349,10 @@ func Test_readJSONFromCommand(t *testing.T) {
 		cmd.Stdout = cw
 		cmd.Stderr = new(bytes.Buffer)
 
-		_ = cmd.Run()
+		exited := reaped(cmd)
 
 		var result protocol.Result
-		err := readJSONFromCommand(&result, cmd)
+		err := readJSONFromCommand(&result, cmd, exited)
 
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "exit code 1")
@@ -326,10 +368,10 @@ func Test_readJSONFromCommand(t *testing.T) {
 		cmd.Stdout = cw
 		cmd.Stderr = new(bytes.Buffer)
 
-		_ = cmd.Run()
+		exited := reaped(cmd)
 
 		var raw map[string]json.RawMessage
-		err := readJSONFromCommand(&raw, cmd)
+		err := readJSONFromCommand(&raw, cmd, exited)
 
 		require.NoError(t, err)
 		assert.Contains(t, raw, "name")

--- a/pkg/runners/descriptor_runner.go
+++ b/pkg/runners/descriptor_runner.go
@@ -29,6 +29,13 @@ type descriptorRunner struct {
 	stdin       io.WriteCloser
 	wrapperFile string // absolute path to written wrapper; empty if no template
 	binaryFile  string // absolute path to compiled binary; empty if not compiled
+
+	// waitErr receives the result of the single cmd.Wait() call, owned by the
+	// reaper goroutine started in Open. exited is closed once the process has
+	// been reaped (ProcessState populated), letting Run detect a crashed
+	// subprocess instead of blocking on its stdout forever.
+	waitErr chan error
+	exited  chan struct{}
 }
 
 func (r *descriptorRunner) String() string { return r.desc.Name }
@@ -156,7 +163,23 @@ func (r *descriptorRunner) Open(ctx context.Context) error {
 
 	r.cmd = cmd
 
-	return cmd.Start()
+	if startErr := cmd.Start(); startErr != nil {
+		return startErr
+	}
+
+	// Single reaper: cmd.Wait() is called exactly once here. Both Run (via
+	// checkWait) and Close observe the result through these channels, avoiding
+	// the "no child processes" error that double-reaping causes.
+	r.waitErr = make(chan error, 1)
+	r.exited = make(chan struct{})
+
+	go func() {
+		err := cmd.Wait()
+		r.waitErr <- err
+		close(r.exited) // ProcessState is set by the time Wait returns
+	}()
+
+	return nil
 }
 
 // Close sends SIGTERM to the subprocess and waits for it to exit,
@@ -166,6 +189,15 @@ func (r *descriptorRunner) Close(ctx context.Context) error {
 		return nil
 	}
 
+	// If the process already exited (e.g. a crash detected during Run), the
+	// reaper has populated waitErr and closed exited; nothing more to stop.
+	select {
+	case <-r.exited:
+		<-r.waitErr // drain so the buffered send is consumed
+		return nil
+	default:
+	}
+
 	// Close stdin so the subprocess receives EOF and can exit cleanly.
 	_ = r.stdin.Close()
 
@@ -173,19 +205,16 @@ func (r *descriptorRunner) Close(ctx context.Context) error {
 		return fmt.Errorf("failed to send SIGTERM to %s process: %w", r.desc.Name, err)
 	}
 
-	done := make(chan error, 1)
-	go func() {
-		done <- r.cmd.Wait()
-	}()
-
+	// The reaper goroutine started in Open owns cmd.Wait(); observe its result
+	// through waitErr rather than calling Wait() again (which would double-reap).
 	select {
 	case <-ctx.Done():
 		killErr := r.cmd.Process.Kill()
-		<-done // drain goroutine regardless of kill outcome
+		<-r.waitErr // drain reaper regardless of kill outcome
 		if killErr != nil {
 			return fmt.Errorf("failed to kill %s process: %w", r.desc.Name, killErr)
 		}
-	case err := <-done:
+	case err := <-r.waitErr:
 		if err != nil {
 			return fmt.Errorf("failed to stop %s process: %w", r.desc.Name, err)
 		}
@@ -206,7 +235,7 @@ func (r *descriptorRunner) Run(_ context.Context, task *protocol.Task) (*protoco
 	}
 
 	result := new(protocol.Result)
-	if readErr := readJSONFromCommand(result, r.cmd); readErr != nil {
+	if readErr := readJSONFromCommand(result, r.cmd, r.exited); readErr != nil {
 		return nil, readErr
 	}
 


### PR DESCRIPTION
This pull request improves the reliability and robustness of subprocess management in the runners, especially around handling subprocess crashes and preventing double-reaping of child processes. The changes ensure that the runner can correctly detect and report subprocess failures, avoid deadlocks, and maintain proper process cleanup. The most important changes are grouped below:

**Subprocess lifecycle management improvements:**

* Added `waitErr` and `exited` channels to the `descriptorRunner` struct to coordinate a single `cmd.Wait()` call and signal process exit to other goroutines, preventing double-reaping and related errors. The reaper goroutine is started in `Open` and both `Run` and `Close` now observe process exit via these channels. [[1]](diffhunk://#diff-9d1553d7d3ca1e6214980be27ccec107d58c5381c08c5fcb49a040b1aaf0b2b0R32-R38) [[2]](diffhunk://#diff-9d1553d7d3ca1e6214980be27ccec107d58c5381c08c5fcb49a040b1aaf0b2b0L159-R182) [[3]](diffhunk://#diff-9d1553d7d3ca1e6214980be27ccec107d58c5381c08c5fcb49a040b1aaf0b2b0R192-R217)

**Robust output handling and error detection:**

* Refactored `checkWait` and `readJSONFromCommand` to take an `exited` channel, allowing them to detect when a subprocess dies without producing output and to return a proper error instead of spinning indefinitely. This ensures that startup crashes are handled gracefully and reported with exit code and stderr. [[1]](diffhunk://#diff-6f53c1ca965840be8912afff52ac819d4e1f8bab6ebc9167496fd8ec7aa2e071L70-R75) [[2]](diffhunk://#diff-6f53c1ca965840be8912afff52ac819d4e1f8bab6ebc9167496fd8ec7aa2e071L81-R107)

**Test enhancements:**

* Updated and expanded tests in `comm_test.go` to cover new exit detection logic, including cases where the subprocess crashes on startup, exits without output, or has output available at exit. Introduced the `reaped` helper to simulate post-exit state. [[1]](diffhunk://#diff-f5e198f6ff8ec56b0148a7dc495d1880a866b5ad41e6b3dc5babb655510dbaa2R8) [[2]](diffhunk://#diff-f5e198f6ff8ec56b0148a7dc495d1880a866b5ad41e6b3dc5babb655510dbaa2R193-R203) [[3]](diffhunk://#diff-f5e198f6ff8ec56b0148a7dc495d1880a866b5ad41e6b3dc5babb655510dbaa2L201-R214) [[4]](diffhunk://#diff-f5e198f6ff8ec56b0148a7dc495d1880a866b5ad41e6b3dc5babb655510dbaa2L213-R226) [[5]](diffhunk://#diff-f5e198f6ff8ec56b0148a7dc495d1880a866b5ad41e6b3dc5babb655510dbaa2L229-R282) [[6]](diffhunk://#diff-f5e198f6ff8ec56b0148a7dc495d1880a866b5ad41e6b3dc5babb655510dbaa2L247-R291) [[7]](diffhunk://#diff-f5e198f6ff8ec56b0148a7dc495d1880a866b5ad41e6b3dc5babb655510dbaa2L267-R312) [[8]](diffhunk://#diff-f5e198f6ff8ec56b0148a7dc495d1880a866b5ad41e6b3dc5babb655510dbaa2L291-R336) [[9]](diffhunk://#diff-f5e198f6ff8ec56b0148a7dc495d1880a866b5ad41e6b3dc5babb655510dbaa2L310-R355) [[10]](diffhunk://#diff-f5e198f6ff8ec56b0148a7dc495d1880a866b5ad41e6b3dc5babb655510dbaa2L329-R374)

**Configuration and environment fixes:**

* Updated the Python runner's `PYTHONPATH` in `install.go` to include both the exercise directory and the shared library directory, ensuring correct module resolution for the wrapper and shared code.