### PR TITLE
Add {rel_exercise_dir} runner token (one import_path for AoC + Euler)

### DIFF
--- a/.changes/unreleased/Fixed-20260713-180809.yaml
+++ b/.changes/unreleased/Fixed-20260713-180809.yaml
@@ -1,0 +1,5 @@
+kind: Fixed
+body: Combined import path accounts for different solution site paths
+time: 2026-07-13T18:08:09.47034688-04:00
+custom:
+    Issue: '#190'

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -217,10 +217,19 @@ _Avoid_: exercise context, runner context
 ## Runner Token
 
 A placeholder (e.g. `{year}`, `{lang_dir}`, `{wrapper_file}`) substituted by elf into
-descriptor fields at runtime. The fixed vocabulary is: `{exercise_dir}`, `{lang_dir}`,
-`{wrapper_file}` (only valid when `template_path` is set — extension derived from it),
+descriptor fields at runtime. The fixed vocabulary is: `{exercise_dir}`, `{rel_exercise_dir}`,
+`{lang_dir}`, `{wrapper_file}` (only valid when `template_path` is set — extension derived from it),
 `{binary_file}`, `{year}`, `{day}`, `{title}`. User-defined values go in `template_vars`, not
 new tokens.
+
+`{rel_exercise_dir}` is the exercise directory relative to the nearest ancestor `go.mod` (the
+exercise path resolved to absolute, then made relative to the enclosing Go module root). Unlike
+`{exercise_dir}` — which is the CLI-supplied path verbatim, so `elf solve .` yields `.` — it is
+invariant to the working directory and to how the path is spelled on the command line, giving a
+stable segment for a Go import path across both [[Kind]]s (`exercises/2019/12-foo`, `euler/42`). It
+is **Go-specific by design**: only the Go runner needs a module-relative import path (Rust and C#
+pin crate/assembly names instead), so the anchor is `go.mod` rather than a language-neutral
+workspace root.
 
 _Avoid_: template variable, placeholder, interpolation variable
 

--- a/docs/adr/0021-rel-exercise-dir-token-anchored-to-go-mod.md
+++ b/docs/adr/0021-rel-exercise-dir-token-anchored-to-go-mod.md
@@ -1,0 +1,47 @@
+# `{rel_exercise_dir}` runner token, anchored to the nearest `go.mod`
+
+The Go runner wrapper `import`s the user's exercise package by its **module-qualified path**, so a Go
+[[Runner Descriptor]] carries `import_path = "github.com/.../{year}/{dir_name}/go"`. Encoding the
+location as AoC identity fields breaks once a second [[Kind]] exists: a [[Problem]] (Euler) has no
+year and lives under a different root (`euler.dir`, ADR-0018). One `import_path` string can name only
+one family's layout, so users toggled two commented lines — and a stale toggle silently produced
+`.../euler/<name>/go` for AoC exercises, which fail to build.
+
+The existing `{exercise_dir}` token carries the family root for both Kinds, but it is the
+**CLI-supplied path verbatim**: `elf solve .` yields `.`, producing the invalid import `..././go`.
+The import path is anchored to the **Go module root**, and no existing token speaks in those
+coordinates.
+
+We add **`{rel_exercise_dir}`**: the exercise directory made relative to the nearest ancestor
+`go.mod`. It yields `exercises/2019/12-foo` / `euler/42` for a shared-root module and `.` for a
+per-exercise module (Exercism-style). One line now serves every Kind and layout:
+`import_path = "github.com/.../{rel_exercise_dir}/go"`.
+
+Two scoping choices: it is **Go-specific** (only Go needs a module-relative import; Rust/C# pin
+crate/assembly names), so the anchor is `go.mod`, not a workspace root. And it is resolved in
+`Prepare` — the first token doing filesystem I/O that can fail — **lazily**, only when a descriptor
+references it, so non-Go runners with no module are untouched and `substituteTokens` stays pure.
+
+## Considered options
+
+- **`{rel_exercise_dir}` anchored to `go.mod` (chosen).** No new config; correct regardless of
+  working directory or `elf solve .`. Go-specific, which is honest — Go alone has the problem.
+- **Reuse `{exercise_dir}`, no code change.** Rejected: fails for `elf solve .` (yields `.`), a
+  workflow the user wants.
+- **A workspace-root config key.** Rejected/deferred — the "single solutions root" redesign ADR-0018
+  already deferred; no non-Go runner needs it.
+- **`error`-returning `substituteTokens`, or fall back to `{exercise_dir}` on no-`go.mod`.** Rejected:
+  the first churns a pure function every token flows through; the second silently reintroduces the
+  broken-import bug this token exists to kill. `Prepare` fails loudly instead.
+
+## Consequences
+
+- New entry in the [[Runner Token]] vocabulary; CONTEXT.md glossary updated.
+- `Prepare` gains a lazy step: if a descriptor references the token, walk up from the absolute
+  exercise dir to the first `go.mod`, compute `filepath.Rel(root, dir)`, and pass it into
+  `substituteTokens`. No reference → no walk; match but no `go.mod` → `Prepare` errors.
+- The walk uses real `os`/`filepath` (not `afero.Fs`), consistent with the runner layer, which shells
+  out to a real compiler.
+- `.` is a valid output (per-exercise module). A shared-URL template over a per-exercise module would
+  render an invalid `.../ ./go`, but that combination is nonsensical and unsupported — not
+  special-cased.

--- a/pkg/runners/descriptor.go
+++ b/pkg/runners/descriptor.go
@@ -47,7 +47,10 @@ func (d RunnerDescriptor) ToCreator() RunnerCreator {
 // substituteTokens replaces built-in token placeholders in s with values derived from meta.
 // wrapperExt is the file extension for {wrapper_file} (e.g. ".py"); empty string is valid.
 // wrapperSubdir, when non-empty, places {wrapper_file} and {binary_file} in a subdirectory of lang_dir.
-func substituteTokens(s string, meta ExerciseMeta, wrapperExt, wrapperSubdir string) string {
+// relExerciseDir is the precomputed {rel_exercise_dir} value (exercise dir relative to the nearest
+// go.mod; see ADR-0021). It is resolved by the caller (Prepare) so this function stays pure; callers
+// with no need for it pass "".
+func substituteTokens(s string, meta ExerciseMeta, wrapperExt, wrapperSubdir, relExerciseDir string) string {
 	langDir := meta.LangDir()
 	wrapperDir := langDir
 	if wrapperSubdir != "" {
@@ -58,6 +61,7 @@ func substituteTokens(s string, meta ExerciseMeta, wrapperExt, wrapperSubdir str
 
 	replacer := strings.NewReplacer(
 		"{exercise_dir}", meta.Dir,
+		"{rel_exercise_dir}", relExerciseDir,
 		"{dir_name}", filepath.Base(meta.Dir),
 		"{lang_dir}", langDir,
 		"{wrapper_file}", wrapperFile,
@@ -71,10 +75,10 @@ func substituteTokens(s string, meta ExerciseMeta, wrapperExt, wrapperSubdir str
 }
 
 // substituteSlice applies substituteTokens to every element of a string slice.
-func substituteSlice(ss []string, meta ExerciseMeta, wrapperExt, wrapperSubdir string) []string {
+func substituteSlice(ss []string, meta ExerciseMeta, wrapperExt, wrapperSubdir, relExerciseDir string) []string {
 	out := make([]string, len(ss))
 	for i, s := range ss {
-		out[i] = substituteTokens(s, meta, wrapperExt, wrapperSubdir)
+		out[i] = substituteTokens(s, meta, wrapperExt, wrapperSubdir, relExerciseDir)
 	}
 
 	return out

--- a/pkg/runners/descriptor_runner.go
+++ b/pkg/runners/descriptor_runner.go
@@ -66,6 +66,8 @@ func (r *descriptorRunner) descriptorReferencesRelDir() bool {
 		}
 	}
 
+	// A read failure here is intentionally ignored: writeWrapper reads the same
+	// template and returns its error, so the failure still surfaces loudly.
 	if r.desc.Prepare.TemplatePath != "" {
 		if b, err := os.ReadFile(r.desc.Prepare.TemplatePath); err == nil &&
 			strings.Contains(string(b), relExerciseDirToken) {

--- a/pkg/runners/descriptor_runner.go
+++ b/pkg/runners/descriptor_runner.go
@@ -56,10 +56,10 @@ func (r *descriptorRunner) writeWrapper(langDir, ext, subdir string) error {
 
 	vars := make(map[string]string, len(r.desc.Prepare.TemplateVars))
 	for k, v := range r.desc.Prepare.TemplateVars {
-		vars[k] = substituteTokens(v, r.meta, ext, subdir)
+		vars[k] = substituteTokens(v, r.meta, ext, subdir, "")
 	}
 
-	substitutedContent := substituteTokens(string(templateBytes), r.meta, ext, subdir)
+	substitutedContent := substituteTokens(string(templateBytes), r.meta, ext, subdir, "")
 
 	tpl, parseErr := template.New("").Parse(substitutedContent)
 	if parseErr != nil {
@@ -113,7 +113,7 @@ func (r *descriptorRunner) Prepare(ctx context.Context) error {
 			continue
 		}
 
-		substituted := substituteSlice(cmdArgs, r.meta, ext, subdir)
+		substituted := substituteSlice(cmdArgs, r.meta, ext, subdir, "")
 		//nolint:gosec // build commands come from user config, not untrusted external input
 		cmd := exec.CommandContext(ctx, substituted[0], substituted[1:]...)
 		cmd.Dir = langDir
@@ -139,7 +139,7 @@ func (r *descriptorRunner) Open(ctx context.Context) error {
 	var cmd *exec.Cmd
 
 	if r.desc.Open.Binary != "" {
-		binaryPath := substituteTokens(r.desc.Open.Binary, r.meta, ext, subdir)
+		binaryPath := substituteTokens(r.desc.Open.Binary, r.meta, ext, subdir, "")
 		absPath, absErr := filepath.Abs(binaryPath)
 		if absErr != nil {
 			return fmt.Errorf("resolving binary path: %w", absErr)
@@ -147,13 +147,13 @@ func (r *descriptorRunner) Open(ctx context.Context) error {
 
 		cmd = exec.CommandContext(ctx, absPath)
 	} else {
-		args := substituteSlice(r.desc.Open.Args, r.meta, ext, subdir)
+		args := substituteSlice(r.desc.Open.Args, r.meta, ext, subdir, "")
 		//nolint:gosec // interpreter and args come from user config
 		cmd = exec.CommandContext(ctx, r.desc.Open.Interpreter, args...)
 	}
 
 	cmd.Dir = r.meta.LangDir()
-	cmd.Env = append(os.Environ(), substituteSlice(r.desc.Open.Env, r.meta, ext, subdir)...)
+	cmd.Env = append(os.Environ(), substituteSlice(r.desc.Open.Env, r.meta, ext, subdir, "")...)
 
 	// Put the subprocess in its own process group so we can signal the entire
 	// tree on timeout. Wrapper runners (e.g. bash) fork children — a $(...) or
@@ -322,7 +322,7 @@ func (r *descriptorRunner) removeCleanupPaths() error {
 			continue
 		}
 
-		resolved := substituteTokens(p, r.meta, r.wrapperExt(), r.desc.Prepare.WrapperSubdir)
+		resolved := substituteTokens(p, r.meta, r.wrapperExt(), r.desc.Prepare.WrapperSubdir, "")
 		// Relative cleanup paths are resolved against the lang dir.
 		if !filepath.IsAbs(resolved) {
 			resolved = filepath.Join(r.meta.LangDir(), resolved)

--- a/pkg/runners/descriptor_runner.go
+++ b/pkg/runners/descriptor_runner.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"syscall"
 	"text/template"
 
@@ -30,6 +31,8 @@ type descriptorRunner struct {
 	wrapperFile string // absolute path to written wrapper; empty if no template
 	binaryFile  string // absolute path to compiled binary; empty if not compiled
 
+	relExerciseDir string // precomputed {rel_exercise_dir} value; empty until Prepare resolves it
+
 	// waitErr receives the result of the single cmd.Wait() call, owned by the
 	// reaper goroutine started in Open. exited is closed once the process has
 	// been reaped (ProcessState populated), letting Run detect a crashed
@@ -44,6 +47,35 @@ func (r *descriptorRunner) wrapperExt() string {
 	return r.desc.Prepare.WrapperExt
 }
 
+const relExerciseDirToken = "{rel_exercise_dir}" //nolint:gosec // template token, not a credential
+
+// descriptorReferencesRelDir reports whether any Prepare-time substitutable field
+// references {rel_exercise_dir}, so Prepare only walks for go.mod when needed.
+func (r *descriptorRunner) descriptorReferencesRelDir() bool {
+	for _, v := range r.desc.Prepare.TemplateVars {
+		if strings.Contains(v, relExerciseDirToken) {
+			return true
+		}
+	}
+
+	for _, cmd := range r.desc.Prepare.BuildCommands {
+		for _, arg := range cmd {
+			if strings.Contains(arg, relExerciseDirToken) {
+				return true
+			}
+		}
+	}
+
+	if r.desc.Prepare.TemplatePath != "" {
+		if b, err := os.ReadFile(r.desc.Prepare.TemplatePath); err == nil &&
+			strings.Contains(string(b), relExerciseDirToken) {
+			return true
+		}
+	}
+
+	return false
+}
+
 func (r *descriptorRunner) writeWrapper(langDir, ext, subdir string) error {
 	if r.desc.Prepare.TemplatePath == "" {
 		return nil
@@ -56,10 +88,10 @@ func (r *descriptorRunner) writeWrapper(langDir, ext, subdir string) error {
 
 	vars := make(map[string]string, len(r.desc.Prepare.TemplateVars))
 	for k, v := range r.desc.Prepare.TemplateVars {
-		vars[k] = substituteTokens(v, r.meta, ext, subdir, "")
+		vars[k] = substituteTokens(v, r.meta, ext, subdir, r.relExerciseDir)
 	}
 
-	substitutedContent := substituteTokens(string(templateBytes), r.meta, ext, subdir, "")
+	substitutedContent := substituteTokens(string(templateBytes), r.meta, ext, subdir, r.relExerciseDir)
 
 	tpl, parseErr := template.New("").Parse(substitutedContent)
 	if parseErr != nil {
@@ -96,6 +128,15 @@ func (r *descriptorRunner) Prepare(ctx context.Context) error {
 	ext := r.wrapperExt()
 	subdir := r.desc.Prepare.WrapperSubdir
 
+	if r.descriptorReferencesRelDir() {
+		rel, relErr := moduleRelDir(r.meta.Dir)
+		if relErr != nil {
+			return fmt.Errorf("resolving {rel_exercise_dir}: %w", relErr)
+		}
+
+		r.relExerciseDir = rel
+	}
+
 	if err := r.writeWrapper(langDir, ext, subdir); err != nil {
 		return err
 	}
@@ -113,7 +154,7 @@ func (r *descriptorRunner) Prepare(ctx context.Context) error {
 			continue
 		}
 
-		substituted := substituteSlice(cmdArgs, r.meta, ext, subdir, "")
+		substituted := substituteSlice(cmdArgs, r.meta, ext, subdir, r.relExerciseDir)
 		//nolint:gosec // build commands come from user config, not untrusted external input
 		cmd := exec.CommandContext(ctx, substituted[0], substituted[1:]...)
 		cmd.Dir = langDir

--- a/pkg/runners/descriptor_runner_test.go
+++ b/pkg/runners/descriptor_runner_test.go
@@ -491,3 +491,29 @@ func TestPrepare_NoRelDirReference_SkipsResolution(t *testing.T) {
 
 	assert.NoError(t, r.Prepare(context.Background()))
 }
+
+func TestPrepare_RelExerciseDirInBuildCommand(t *testing.T) {
+	root := t.TempDir()
+	writeGoMod(t, root)
+	exDir := filepath.Join(root, "exercises", "2015", "01-foo")
+	require.NoError(t, os.MkdirAll(exDir, 0o755))
+
+	outFile := filepath.Join(root, "out.txt")
+	desc := RunnerDescriptor{
+		Key: "go", Name: "Go",
+		Prepare: PrepareSpec{
+			// No template; the token appears only in a build command arg.
+			BuildCommands: [][]string{
+				{"sh", "-c", "printf '%s' '{rel_exercise_dir}' > " + outFile},
+			},
+		},
+	}
+	meta := ExerciseMeta{Year: 2015, Day: 1, Title: "foo", Dir: exDir, Key: "go"}
+	r := desc.ToCreator()(meta).(*descriptorRunner)
+
+	require.NoError(t, r.Prepare(context.Background()))
+
+	got, err := os.ReadFile(outFile)
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Join("exercises", "2015", "01-foo"), string(got))
+}

--- a/pkg/runners/descriptor_runner_test.go
+++ b/pkg/runners/descriptor_runner_test.go
@@ -416,3 +416,78 @@ func TestDescriptorRunner_Run_PanicInExerciseDoesNotHang(t *testing.T) {
 		require.Fail(t, "Run hung after the exercise subprocess panicked and exited (issue #48 regression)")
 	}
 }
+
+func TestPrepare_ResolvesRelExerciseDirToken(t *testing.T) {
+	root := t.TempDir()
+	writeGoMod(t, root)
+	exDir := filepath.Join(root, "exercises", "2015", "01-foo")
+	require.NoError(t, os.MkdirAll(exDir, 0o755))
+
+	tmplPath := filepath.Join(root, "go.tmpl")
+	require.NoError(t, os.WriteFile(tmplPath, []byte(`import {{ index . "import_path" }}`), 0o600))
+
+	desc := RunnerDescriptor{
+		Key: "go", Name: "Go",
+		Prepare: PrepareSpec{
+			TemplatePath:  tmplPath,
+			WrapperExt:    ".go",
+			WrapperSubdir: "cmd",
+			TemplateVars:  map[string]string{"import_path": "mod/{rel_exercise_dir}/go"},
+		},
+	}
+	meta := ExerciseMeta{Year: 2015, Day: 1, Title: "foo", Dir: exDir, Key: "go"}
+	r := desc.ToCreator()(meta).(*descriptorRunner)
+
+	require.NoError(t, r.Prepare(context.Background()))
+
+	got, err := os.ReadFile(filepath.Join(exDir, "go", "cmd", "runtime-wrapper.go"))
+	require.NoError(t, err)
+	assert.Contains(t, string(got), "import mod/exercises/2015/01-foo/go")
+}
+
+func TestPrepare_RelExerciseDirNoGoMod(t *testing.T) {
+	root := t.TempDir() // no go.mod
+	exDir := filepath.Join(root, "exercises", "2015", "01-foo")
+	require.NoError(t, os.MkdirAll(exDir, 0o755))
+
+	tmplPath := filepath.Join(root, "go.tmpl")
+	require.NoError(t, os.WriteFile(tmplPath, []byte(`import {{ index . "import_path" }}`), 0o600))
+
+	desc := RunnerDescriptor{
+		Key: "go", Name: "Go",
+		Prepare: PrepareSpec{
+			TemplatePath: tmplPath, WrapperExt: ".go", WrapperSubdir: "cmd",
+			TemplateVars: map[string]string{"import_path": "mod/{rel_exercise_dir}/go"},
+		},
+	}
+	meta := ExerciseMeta{Year: 2015, Day: 1, Title: "foo", Dir: exDir, Key: "go"}
+	r := desc.ToCreator()(meta).(*descriptorRunner)
+
+	err := r.Prepare(context.Background())
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no go.mod found")
+}
+
+func TestPrepare_NoRelDirReference_SkipsResolution(t *testing.T) {
+	// No go.mod anywhere, but the descriptor never references the token, so
+	// Prepare must NOT walk for go.mod and must NOT fail (non-Go runner case).
+	root := t.TempDir()
+	exDir := filepath.Join(root, "exercises", "2015", "01-foo")
+	require.NoError(t, os.MkdirAll(exDir, 0o755))
+
+	tmplPath := filepath.Join(root, "py.tmpl")
+	require.NoError(t, os.WriteFile(tmplPath, []byte(`print("hi {{ index . "x" }}")`), 0o600))
+
+	desc := RunnerDescriptor{
+		Key: "py", Name: "Python",
+		Prepare: PrepareSpec{
+			TemplatePath: tmplPath, WrapperExt: ".py",
+			TemplateVars: map[string]string{"x": "{title}"},
+		},
+	}
+	meta := ExerciseMeta{Year: 2015, Day: 1, Title: "foo", Dir: exDir, Key: "py"}
+	r := desc.ToCreator()(meta).(*descriptorRunner)
+
+	assert.NoError(t, r.Prepare(context.Background()))
+}

--- a/pkg/runners/descriptor_test.go
+++ b/pkg/runners/descriptor_test.go
@@ -61,10 +61,18 @@ func TestSubstituteTokens(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := substituteTokens(tt.input, meta, tt.wrapperExt, "")
+			got := substituteTokens(tt.input, meta, tt.wrapperExt, "", "")
 			assert.Equal(t, tt.want, got)
 		})
 	}
+}
+
+func TestSubstituteTokens_RelExerciseDir(t *testing.T) {
+	meta := ExerciseMeta{Year: 2015, Day: 1, Title: "foo", Dir: "exercises/2015/01-foo", Key: "go"}
+
+	got := substituteTokens("mod/{rel_exercise_dir}/go", meta, ".go", "", "exercises/2015/01-foo")
+
+	assert.Equal(t, "mod/exercises/2015/01-foo/go", got)
 }
 
 func TestRunnerDescriptor_ToCreator(t *testing.T) {

--- a/pkg/runners/modulepath.go
+++ b/pkg/runners/modulepath.go
@@ -1,0 +1,38 @@
+package runners
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// moduleRelDir returns exerciseDir relative to the directory of the nearest
+// ancestor go.mod (the enclosing Go module root). exerciseDir may be relative,
+// ".", or absolute; it is resolved against the process working directory first.
+//
+// This is the resolver behind the {rel_exercise_dir} runner token (ADR-0021).
+// It is Go-specific by design: only the Go runner needs a module-relative import
+// path, so the anchor is go.mod. The walk starts at the exercise dir itself, so a
+// per-exercise module (go.mod inside the exercise dir) correctly yields ".".
+func moduleRelDir(exerciseDir string) (string, error) {
+	abs, err := filepath.Abs(exerciseDir)
+	if err != nil {
+		return "", fmt.Errorf("resolving exercise dir %q: %w", exerciseDir, err)
+	}
+
+	for dir := abs; ; {
+		if _, statErr := os.Stat(filepath.Join(dir, "go.mod")); statErr == nil {
+			rel, relErr := filepath.Rel(dir, abs)
+			if relErr != nil {
+				return "", fmt.Errorf("relativizing %q to module root %q: %w", abs, dir, relErr)
+			}
+			return rel, nil
+		}
+
+		parent := filepath.Dir(dir)
+		if parent == dir { // reached filesystem root
+			return "", fmt.Errorf("no go.mod found above %q", abs)
+		}
+		dir = parent
+	}
+}

--- a/pkg/runners/modulepath_test.go
+++ b/pkg/runners/modulepath_test.go
@@ -1,0 +1,63 @@
+package runners
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// writeGoMod creates dir (and parents) and puts an empty go.mod in it.
+func writeGoMod(t *testing.T, dir string) {
+	t.Helper()
+	require.NoError(t, os.MkdirAll(dir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "go.mod"), []byte("module test\n"), 0o600))
+}
+
+func TestModuleRelDir_SharedRootModule(t *testing.T) {
+	root := t.TempDir()
+	writeGoMod(t, root)
+	ex := filepath.Join(root, "exercises", "2019", "12-foo")
+	require.NoError(t, os.MkdirAll(ex, 0o755))
+
+	got, err := moduleRelDir(ex)
+
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Join("exercises", "2019", "12-foo"), got)
+}
+
+func TestModuleRelDir_EulerSibling(t *testing.T) {
+	root := t.TempDir()
+	writeGoMod(t, root)
+	ex := filepath.Join(root, "euler", "42")
+	require.NoError(t, os.MkdirAll(ex, 0o755))
+
+	got, err := moduleRelDir(ex)
+
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Join("euler", "42"), got)
+}
+
+func TestModuleRelDir_PerExerciseModule(t *testing.T) {
+	root := t.TempDir()
+	ex := filepath.Join(root, "tracks", "go", "hamming")
+	writeGoMod(t, ex) // go.mod IS in the exercise dir
+
+	got, err := moduleRelDir(ex)
+
+	require.NoError(t, err)
+	assert.Equal(t, ".", got)
+}
+
+func TestModuleRelDir_NoGoMod(t *testing.T) {
+	root := t.TempDir() // no go.mod anywhere
+	ex := filepath.Join(root, "exercises", "2019", "12-foo")
+	require.NoError(t, os.MkdirAll(ex, 0o755))
+
+	_, err := moduleRelDir(ex)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no go.mod found")
+}

--- a/pkg/runners/modulepath_test.go
+++ b/pkg/runners/modulepath_test.go
@@ -61,3 +61,18 @@ func TestModuleRelDir_NoGoMod(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "no go.mod found")
 }
+
+func TestModuleRelDir_RelativeAndDotInput(t *testing.T) {
+	root := t.TempDir()
+	writeGoMod(t, root)
+	exDir := filepath.Join(root, "exercises", "2015", "01-foo")
+	require.NoError(t, os.MkdirAll(exDir, 0o755))
+
+	// chdir into the exercise dir and resolve ".", mimicking `elf solve .`
+	t.Chdir(exDir)
+
+	got, err := moduleRelDir(".")
+
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Join("exercises", "2015", "01-foo"), got)
+}


### PR DESCRIPTION
## Summary

Adds a `{rel_exercise_dir}` runner token so a single Go `import_path` config line works for both exercise Kinds (Advent of Code and Project Euler) and survives `elf solve .`.

Before this, the Go runner's `import_path` encoded the exercise location as `{year}/{dir_name}`. That can't serve both Kinds from one line — a Puzzle (AoC) has a year and lives under `advent.dir`; a Problem (Euler, #48/#0018) has no year and lives under `euler.dir`. Users worked around it by toggling two mutually-exclusive commented lines, and a stale toggle silently produced broken `.../euler/<name>/go` imports for AoC exercises:

```
no required module provides package github.com/asphaltbuffet/advent-of-code/euler/12-theN-BodyProblem/go
```

## The token

`{rel_exercise_dir}` = the exercise directory relative to the **nearest ancestor `go.mod`**. One line now covers every Kind and both module layouts:

```toml
template_vars = { import_path = "github.com/asphaltbuffet/advent-of-code/{rel_exercise_dir}/go" }
```

- AoC → `exercises/2019/12-theN-BodyProblem`
- Euler → `euler/1`
- per-exercise module (Exercism-style `go.mod` in the exercise dir) → `.`

Unlike the existing `{exercise_dir}` token (the CLI path verbatim, which yields `.` for `elf solve .`), it is anchored to the module root, so it is invariant to the working directory and how the path is spelled.

## Design (ADR-0021)

Two deliberate scoping choices, both documented in `docs/adr/0021-...`:

- **Go-specific.** Only the Go runner needs a module-relative import path (Rust/C# pin crate/assembly names), so the anchor is `go.mod`, not a language-neutral workspace root (the workspace-root redesign deferred in ADR-0018 stays deferred).
- **Resolved in `Prepare`, lazily.** This is the first token doing filesystem I/O that can fail. Rather than make the pure `substituteTokens` substituter fallible, `Prepare` resolves the value up front (where errors already propagate) and passes it in as a precomputed string. Resolution is lazy — the `go.mod` walk fires only when a descriptor actually references the token, so non-Go runners with no module are unaffected. On a referenced-but-unresolvable token, `Prepare` fails loudly (`no go.mod found ...`) rather than falling back and reintroducing the broken-import bug.

## Changes

- `pkg/runners/modulepath.go` — `moduleRelDir` resolver (walk to nearest `go.mod`, then `filepath.Rel`).
- `pkg/runners/descriptor.go` — `substituteTokens`/`substituteSlice` gain a precomputed `relExerciseDir` param and a `{rel_exercise_dir}` replacer entry; both stay pure and infallible.
- `pkg/runners/descriptor_runner.go` — lazy resolution in `Prepare` via `descriptorReferencesRelDir` (scans template vars, build commands, and the wrapper template contents).
- `docs/adr/0021-rel-exercise-dir-token-anchored-to-go-mod.md`, `CONTEXT.md` — ADR + glossary entry.

## Verification

- `mise run dev` green: lint 0 issues, snapshot builds.
- `mise run test`: 553 tests pass, 1 pre-existing unrelated skip (`cmd/config TestInteractiveInit`).
- Real-repo acceptance against the solutions repo (all pass):
  1. `elf solve exercises/2019/12-theN-BodyProblem` from repo root — the originally-failing command → PASS (both parts).
  2. `elf solve .` from inside the exercise dir — the case `{exercise_dir}` cannot handle → PASS (both parts).
  3. `elf solve euler/1` — same `import_path` line, other Kind → PASS (Part One only, per the Euler single-part model).
