### PR TITLE
Refactor exercise to reuse getH2NodeFromHTML and fix comments

### DIFF
--- a/pkg/exercise/problem.go
+++ b/pkg/exercise/problem.go
@@ -143,8 +143,8 @@ func (p *ProblemAdder) Add() error {
 	case err == nil:
 		p.title = title
 	case errors.Is(err, ErrInvalidData):
-		// A fetched page with no title means the number does not exist: hard-fail
-		// so a typo'd number leaves nothing scaffolded behind.
+		// A redirect (or, as a secondary guard, a heading-less page) means the
+		// number does not exist: hard-fail so a typo'd number scaffolds nothing.
 		p.logger.Error("problem not found", slog.Int("number", p.number), tint.Err(err))
 		return fmt.Errorf("problem %d not found: %w", p.number, err)
 	default:

--- a/pkg/exercise/problem_fetcher.go
+++ b/pkg/exercise/problem_fetcher.go
@@ -18,43 +18,26 @@ import (
 // <h2> yields an ErrInvalidData error, which fetchTitle treats as a secondary
 // bad-number guard — the primary signal is a redirect (see fetchTitle), since
 // projecteuler.net redirects an out-of-range number to /archives rather than
-// serving a heading-less page. This is deliberately separate from the AoC title
-// extractor (extractTitle) so drift in either site's markup touches only its
-// own path.
+// serving a heading-less page. It shares the generic getH2NodeFromHTML walk with
+// the AoC extractor (extractTitle) but keeps its own interpretation — euler's
+// <h2> is the bare title, so site-specific markup drift touches only this line.
 func extractProblemTitle(page []byte) (string, error) {
 	doc, err := html.Parse(bytes.NewReader(page))
 	if err != nil {
 		return "", fmt.Errorf("parsing problem page: %w", err)
 	}
 
-	var (
-		text    string
-		found   bool
-		crawler func(*html.Node)
-	)
-
-	crawler = func(node *html.Node) {
-		if found {
-			return
-		}
-
-		if node.Type == html.ElementNode && node.Data == "h2" {
-			if node.FirstChild != nil && node.FirstChild.Type == html.TextNode {
-				text = node.FirstChild.Data
-			}
-			found = true
-			return
-		}
-
-		for c := node.FirstChild; c != nil; c = c.NextSibling {
-			crawler(c)
-		}
+	// Reuse the shared <h2> walk; euler differs from AoC only in interpretation —
+	// its <h2> holds the bare title, so we take the text directly instead of
+	// stripping AoC's "--- Day N: ... ---" decoration.
+	h2, err := getH2NodeFromHTML(doc)
+	if err != nil {
+		return "", err
 	}
 
-	crawler(doc)
-
-	if !found {
-		return "", fmt.Errorf("%w: no problem title found", ErrInvalidData)
+	var text string
+	if h2.FirstChild != nil && h2.FirstChild.Type == html.TextNode {
+		text = h2.FirstChild.Data
 	}
 
 	return strings.TrimSpace(text), nil


### PR DESCRIPTION
This pull request refactors how the problem title is extracted from Project Euler pages to improve maintainability and reduce duplication. The extraction now shares a common HTML walk function with the AoC extractor, but keeps site-specific logic isolated. Additionally, comments and error handling have been updated for clarity.

**Refactoring and code reuse:**

* [`pkg/exercise/problem_fetcher.go`](diffhunk://#diff-47051e308733d005b163e6a766a2af5480ba37a4b57ac42f6bbbfd93aebf7b27L21-R40): Replaced the custom `<h2>` extraction logic in `extractProblemTitle` with a call to the shared `getH2NodeFromHTML` function, ensuring that only site-specific interpretation differs between Project Euler and AoC.

**Documentation and error handling:**

* [`pkg/exercise/problem_fetcher.go`](diffhunk://#diff-47051e308733d005b163e6a766a2af5480ba37a4b57ac42f6bbbfd93aebf7b27L21-R40): Updated comments to clarify that Project Euler and AoC now share the same HTML node walker but interpret the results differently.
* [`pkg/exercise/problem.go`](diffhunk://#diff-960d25a792b2daa472e4915ecd19636bd91a1d07c7d98c9c54f24d82abc691f7L146-R147): Improved the error handling and comments in `ProblemAdder.Add` to clarify that a redirect or missing heading means the problem number does not exist, preventing accidental scaffolding for invalid numbers.